### PR TITLE
Fix UI Scaling bug

### DIFF
--- a/Api.cs
+++ b/Api.cs
@@ -57,8 +57,22 @@ namespace GenericModConfigMenu
 
     public class Api : IApi
     {
+        internal static Action<string, LogLevel> apiLog;
+
         public void RegisterModConfig(IManifest mod, Action revertToDefault, Action saveToFile)
         {
+            if (mod is null) {
+                apiLog("mod is null! Who called me??", LogLevel.Error);
+                throw new ArgumentNullException("mod");
+                }
+            if (revertToDefault is null) {
+                apiLog($"{mod.UniqueID} gave null revertToDefault!", LogLevel.Error);
+                throw new ArgumentNullException("revertToDefault");
+                }
+            if (saveToFile is null) {
+                apiLog($"{mod.UniqueID} gave null saveToFile!", LogLevel.Error);
+                throw new ArgumentNullException("saveToFile");
+                }
             if (Mod.instance.configs.ContainsKey(mod))
                 throw new ArgumentException("Mod already registered");
             Mod.instance.configs.Add(mod, new ModConfig(mod, revertToDefault, saveToFile));

--- a/GenericModConfigMenu.csproj
+++ b/GenericModConfigMenu.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>GenericModConfigMenu</AssemblyName>
     <RootNamespace>GenericModConfigMenu</RootNamespace>
-    <Version>1.3.4.2</Version>
+    <Version>1.3.4.4</Version>
     <TargetFramework>net452</TargetFramework>
     <Platforms>AnyCPU</Platforms>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/GenericModConfigMenu.csproj
+++ b/GenericModConfigMenu.csproj
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <AssemblyName>GenericModConfigMenu</AssemblyName>
     <RootNamespace>GenericModConfigMenu</RootNamespace>
-    <Version>1.1.0</Version>
+    <Version>1.3.4.2</Version>
     <TargetFramework>net452</TargetFramework>
-    <Platforms>x86</Platforms>
-    <PlatformTarget>x86</PlatformTarget>
+    <Platforms>AnyCPU</Platforms>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.1.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.3.0" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/Mod.cs
+++ b/Mod.cs
@@ -35,7 +35,7 @@ namespace GenericModConfigMenu
 
             Texture2D tex = Helper.Content.Load<Texture2D>("assets/config-button.png");
             configButton = new Button(tex) {
-                LocalPosition = new Vector2(36, Game1.uiViewport.Height - 100),
+                LocalPosition = new Vector2(36, Game1.viewport.Height - 100),
                 Callback =
                     (Element e) => {
                         Game1.playSound("newArtifact");
@@ -175,7 +175,7 @@ namespace GenericModConfigMenu
 
         private void onWindowResized(object sender, WindowResizedEventArgs e)
         {
-            configButton.LocalPosition = new Vector2(configButton.Position.X, Game1.uiViewport.Height - 100);
+            configButton.LocalPosition = new Vector2(configButton.Position.X, Game1.viewport.Height - 100);
         }
 
         private void onRendered(object sender, RenderedEventArgs e)

--- a/Mod.cs
+++ b/Mod.cs
@@ -26,23 +26,26 @@ namespace GenericModConfigMenu
 
         public override void Entry(IModHelper helper)
         {
+            Monitor.Log($"GMCM version {ModManifest.Version} loading...", LogLevel.Info);
             instance = this;
             Log.Monitor = Monitor;
+            Api.apiLog = Monitor.Log;
 
             ui = new RootElement();
 
             Texture2D tex = Helper.Content.Load<Texture2D>("assets/config-button.png");
-            configButton = new Button(tex);
-            configButton.LocalPosition = new Vector2(36, Game1.viewport.Height - 100);
-            configButton.Callback = (Element e) =>
-            {
-                Game1.playSound("newArtifact");
-                TitleMenu.subMenu = new ModConfigMenu( false );
-            };
+            configButton = new Button(tex) {
+                LocalPosition = new Vector2(36, Game1.uiViewport.Height - 100),
+                Callback =
+                    (Element e) => {
+                        Game1.playSound("newArtifact");
+                        TitleMenu.subMenu = new ModConfigMenu(false);
+                    }
+                };
 
             ui.AddChild(configButton);
 
-            helper.Events.GameLoop.GameLaunched += onLaunched;
+            //helper.Events.GameLoop.GameLaunched += onLaunched;
             helper.Events.GameLoop.UpdateTicking += onUpdate;
             helper.Events.Display.WindowResized += onWindowResized;
             helper.Events.Display.Rendered += onRendered;
@@ -78,77 +81,77 @@ namespace GenericModConfigMenu
             public Color color;
         }
 
-        private void onLaunched(object sender, GameLaunchedEventArgs e)
-        {
-            config = Helper.ReadConfig<DummyConfig>();
-            var api = Helper.ModRegistry.GetApi<IApi>(ModManifest.UniqueID);
-            api.RegisterModConfig(ModManifest, () => config = new DummyConfig(), () => Helper.WriteConfig(config));
-            api.SetDefaultIngameOptinValue( ModManifest, true );
-            api.RegisterLabel(ModManifest, "Dummy Label", "Testing labels");
-            api.RegisterParagraph( ModManifest, "Testing paragraph text. These are smaller than labels and should wrap based on length. In theory. They should also (in theory) support multiple rows. Whether that will look good or not is another question. But hey, it looks like it worked! Imagine that. Should I support images in documentation, too?" );
-            api.RegisterImage( ModManifest, "Maps\\springobjects", new Rectangle( 32, 48, 16, 16 ) );
-            api.RegisterImage( ModManifest, "Portraits\\Penny", null, 1 );
-            api.SetDefaultIngameOptinValue( ModManifest, false );
-            api.RegisterPageLabel( ModManifest, "Go to page: Simple Options", "", "Simple Options" );
-            api.SetDefaultIngameOptinValue( ModManifest, true );
-            api.RegisterPageLabel( ModManifest, "Go to page: Complex Options", "", "Complex Options" );
-            api.SetDefaultIngameOptinValue( ModManifest, false );
-            api.StartNewPage( ModManifest, "Simple Options" );
-            api.RegisterPageLabel( ModManifest, "Back to main page", "", "" );
-            api.RegisterSimpleOption(ModManifest, "Dummy Bool", "Testing a checkbox", () => config.dummyBool, (bool val) => config.dummyBool = val);
-            api.RegisterSimpleOption(ModManifest, "Dummy Int (1)", "Testing an int (simple)", () => config.dummyInt1, (int val) => config.dummyInt1 = val);
-            api.RegisterClampedOption(ModManifest, "Dummy Int (2)", "Testing an int (range)", () => config.dummyInt2, (int val) => config.dummyInt2 = val, 0, 100);
-            api.RegisterSimpleOption(ModManifest, "Dummy Float (1)", "Testing a float (simple)", () => config.dummyFloat1, (float val) => config.dummyFloat1 = val);
-            api.RegisterClampedOption(ModManifest, "Dummy Float (2)", "Testing a float (range)", () => config.dummyFloat2, (float val) => config.dummyFloat2 = val, 0, 1);
-            api.SetDefaultIngameOptinValue( ModManifest, true );
-            api.StartNewPage( ModManifest, "Complex Options" );
-            api.RegisterPageLabel( ModManifest, "Back to main page", "", "" );
-            api.RegisterSimpleOption(ModManifest, "Dummy String (1)", "Testing a string", () => config.dummyString1, (string val) => config.dummyString1 = val);
-            api.RegisterChoiceOption(ModManifest, "Dummy String (2)", "Testing a dropdown box", () => config.dummyString2, (string val) => config.dummyString2 = val, DummyConfig.dummyString2Choices);
-            api.RegisterSimpleOption(ModManifest, "Dummy Keybinding", "Testing a keybinding", () => config.dummyKeybinding, (SButton val) => config.dummyKeybinding = val);
-            api.RegisterSimpleOption(ModManifest, "Dummy Keybinding 2", "Testing a keybinding list", () => config.dummyKeybinding2, (KeybindList val) => config.dummyKeybinding2 = val);
+        //private void onLaunched(object sender, GameLaunchedEventArgs e)
+        //{
+        //    config = Helper.ReadConfig<DummyConfig>();
+        //    var api = Helper.ModRegistry.GetApi<IApi>(ModManifest.UniqueID);
+        //    api.RegisterModConfig(ModManifest, () => config = new DummyConfig(), () => Helper.WriteConfig(config));
+        //    api.SetDefaultIngameOptinValue( ModManifest, true );
+        //    api.RegisterLabel(ModManifest, "Dummy Label", "Testing labels");
+        //    api.RegisterParagraph( ModManifest, "Testing paragraph text. These are smaller than labels and should wrap based on length. In theory. They should also (in theory) support multiple rows. Whether that will look good or not is another question. But hey, it looks like it worked! Imagine that. Should I support images in documentation, too?" );
+        //    api.RegisterImage( ModManifest, "Maps\\springobjects", new Rectangle( 32, 48, 16, 16 ) );
+        //    api.RegisterImage( ModManifest, "Portraits\\Penny", null, 1 );
+        //    api.SetDefaultIngameOptinValue( ModManifest, false );
+        //    api.RegisterPageLabel( ModManifest, "Go to page: Simple Options", "", "Simple Options" );
+        //    api.SetDefaultIngameOptinValue( ModManifest, true );
+        //    api.RegisterPageLabel( ModManifest, "Go to page: Complex Options", "", "Complex Options" );
+        //    api.SetDefaultIngameOptinValue( ModManifest, false );
+        //    api.StartNewPage( ModManifest, "Simple Options" );
+        //    api.RegisterPageLabel( ModManifest, "Back to main page", "", "" );
+        //    api.RegisterSimpleOption(ModManifest, "Dummy Bool", "Testing a checkbox", () => config.dummyBool, (bool val) => config.dummyBool = val);
+        //    api.RegisterSimpleOption(ModManifest, "Dummy Int (1)", "Testing an int (simple)", () => config.dummyInt1, (int val) => config.dummyInt1 = val);
+        //    api.RegisterClampedOption(ModManifest, "Dummy Int (2)", "Testing an int (range)", () => config.dummyInt2, (int val) => config.dummyInt2 = val, 0, 100);
+        //    api.RegisterSimpleOption(ModManifest, "Dummy Float (1)", "Testing a float (simple)", () => config.dummyFloat1, (float val) => config.dummyFloat1 = val);
+        //    api.RegisterClampedOption(ModManifest, "Dummy Float (2)", "Testing a float (range)", () => config.dummyFloat2, (float val) => config.dummyFloat2 = val, 0, 1);
+        //    api.SetDefaultIngameOptinValue( ModManifest, true );
+        //    api.StartNewPage( ModManifest, "Complex Options" );
+        //    api.RegisterPageLabel( ModManifest, "Back to main page", "", "" );
+        //    api.RegisterSimpleOption(ModManifest, "Dummy String (1)", "Testing a string", () => config.dummyString1, (string val) => config.dummyString1 = val);
+        //    api.RegisterChoiceOption(ModManifest, "Dummy String (2)", "Testing a dropdown box", () => config.dummyString2, (string val) => config.dummyString2 = val, DummyConfig.dummyString2Choices);
+        //    api.RegisterSimpleOption(ModManifest, "Dummy Keybinding", "Testing a keybinding", () => config.dummyKeybinding, (SButton val) => config.dummyKeybinding = val);
+        //    api.RegisterSimpleOption(ModManifest, "Dummy Keybinding 2", "Testing a keybinding list", () => config.dummyKeybinding2, (KeybindList val) => config.dummyKeybinding2 = val);
 
-            api.RegisterLabel(ModManifest, "", "");
+        //    api.RegisterLabel(ModManifest, "", "");
 
-            // Complex widget - this just generates a random  color on click.
-            Func<Vector2, object, object> randomColorUpdate =
-            (Vector2 pos, object state_) =>
-            {
-                var state = state_ as RandomColorWidgetState;
-                if (state == null)
-                    state = new RandomColorWidgetState() { color = config.dummyColor };
+        //    // Complex widget - this just generates a random  color on click.
+        //    Func<Vector2, object, object> randomColorUpdate =
+        //    (Vector2 pos, object state_) =>
+        //    {
+        //        var state = state_ as RandomColorWidgetState;
+        //        if (state == null)
+        //            state = new RandomColorWidgetState() { color = config.dummyColor };
 
-                var bounds = new Rectangle((int)pos.X + 12, (int)pos.Y + 12, 50 - 12 * 2, 50 - 12 * 2);
-                bool hover = bounds.Contains(Game1.getOldMouseX(), Game1.getOldMouseY());
-                if ( hover && Game1.oldMouseState.LeftButton == ButtonState.Released && Mouse.GetState().LeftButton == ButtonState.Pressed)
-                {
-                    Game1.playSound("drumkit6");
-                    Random r = new Random();
-                    state.color.R = (byte) r.Next(256);
-                    state.color.G = (byte) r.Next(256);
-                    state.color.B = (byte) r.Next(256);
-                }
+        //        var bounds = new Rectangle((int)pos.X + 12, (int)pos.Y + 12, 50 - 12 * 2, 50 - 12 * 2);
+        //        bool hover = bounds.Contains(Game1.getOldMouseX(), Game1.getOldMouseY());
+        //        if ( hover && Game1.oldMouseState.LeftButton == ButtonState.Released && Mouse.GetState().LeftButton == ButtonState.Pressed)
+        //        {
+        //            Game1.playSound("drumkit6");
+        //            Random r = new Random();
+        //            state.color.R = (byte) r.Next(256);
+        //            state.color.G = (byte) r.Next(256);
+        //            state.color.B = (byte) r.Next(256);
+        //        }
 
-                return state;
-            };
-            Func<SpriteBatch, Vector2, object, object> randomColorDraw =
-            (SpriteBatch b, Vector2 pos, object state_) =>
-            {
-                var state = state_ as RandomColorWidgetState;
-                IClickableMenu.drawTextureBox(b, (int)pos.X, (int)pos.Y, 50, 50, Color.White);
-                var colorBox = new Rectangle((int)pos.X + 12, (int)pos.Y + 12, 50 - 12 * 2, 50 - 12 * 2);
-                b.Draw(Game1.staminaRect, colorBox, state.color);
-                return state;
-            };
-            Action<object> randomColorSave =
-            (object state) =>
-            {
-                if ( state == null )
-                    return;
-                config.dummyColor = (state as RandomColorWidgetState).color;
-            };
-            api.RegisterComplexOption(ModManifest, "Dummy Color", "Testing a complex widget (random color on click)", randomColorUpdate, randomColorDraw, randomColorSave);
-        }
+        //        return state;
+        //    };
+        //    Func<SpriteBatch, Vector2, object, object> randomColorDraw =
+        //    (SpriteBatch b, Vector2 pos, object state_) =>
+        //    {
+        //        var state = state_ as RandomColorWidgetState;
+        //        IClickableMenu.drawTextureBox(b, (int)pos.X, (int)pos.Y, 50, 50, Color.White);
+        //        var colorBox = new Rectangle((int)pos.X + 12, (int)pos.Y + 12, 50 - 12 * 2, 50 - 12 * 2);
+        //        b.Draw(Game1.staminaRect, colorBox, state.color);
+        //        return state;
+        //    };
+        //    Action<object> randomColorSave =
+        //    (object state) =>
+        //    {
+        //        if ( state == null )
+        //            return;
+        //        config.dummyColor = (state as RandomColorWidgetState).color;
+        //    };
+        //    api.RegisterComplexOption(ModManifest, "Dummy Color", "Testing a complex widget (random color on click)", randomColorUpdate, randomColorDraw, randomColorSave);
+        //}
 
         private bool isTitleMenuInteractable()
         {
@@ -172,7 +175,7 @@ namespace GenericModConfigMenu
 
         private void onWindowResized(object sender, WindowResizedEventArgs e)
         {
-            configButton.LocalPosition = new Vector2(configButton.Position.X, Game1.viewport.Height - 100);
+            configButton.LocalPosition = new Vector2(configButton.Position.X, Game1.uiViewport.Height - 100);
         }
 
         private void onRendered(object sender, RenderedEventArgs e)

--- a/ModConfig.cs
+++ b/ModConfig.cs
@@ -44,7 +44,8 @@ namespace GenericModConfigMenu
             ModManifest = manifest;
             RevertToDefault = revertToDefault;
             SaveToFile = saveToFile;
-            Options.Add( "", ActiveRegisteringPage = new ModPage( "" ) );
+            ActiveRegisteringPage = new ModPage("");
+            Options.Add("", ActiveRegisteringPage);
         }
     }
 }

--- a/ModConfigMenu.cs
+++ b/ModConfigMenu.cs
@@ -46,8 +46,10 @@ namespace GenericModConfigMenu
 
             ui.AddChild(table);
 
-            if (ingame || Constants.TargetPlatform == GamePlatform.Android)
+            if (Constants.TargetPlatform == GamePlatform.Android)
                 initializeUpperRightCloseButton();
+            else
+                upperRightCloseButton = null;
 
             ActiveConfigMenu = this;
         }

--- a/ModConfigMenu.cs
+++ b/ModConfigMenu.cs
@@ -28,8 +28,8 @@ namespace GenericModConfigMenu
 
             table = new Table();
             table.RowHeight = 50;
-            table.LocalPosition = new Vector2((Game1.viewport.Width - 800) / 2, 64);
-            table.Size = new Vector2(800, Game1.viewport.Height - 128);
+            table.LocalPosition = new Vector2((Game1.uiViewport.Width - 800) / 2, 64);
+            table.Size = new Vector2(800, Game1.uiViewport.Height - 128);
 
             var heading = new Label() { String = "Configure Mods", Bold = true };
             heading.LocalPosition = new Vector2((800 - heading.Measure().X) / 2, heading.LocalPosition.Y);
@@ -80,7 +80,7 @@ namespace GenericModConfigMenu
         public override void draw(SpriteBatch b)
         {
             base.draw(b);
-            b.Draw(Game1.staminaRect, new Rectangle(0, 0, Game1.viewport.Width, Game1.viewport.Height), new Color(0, 0, 0, 192));
+            b.Draw(Game1.staminaRect, new Rectangle(0, 0, Game1.uiViewport.Width, Game1.uiViewport.Height), new Color(0, 0, 0, 192));
             ui.Draw(b);
             if ( upperRightCloseButton != null )
                 upperRightCloseButton.draw(b); // bring it above the backdrop
@@ -102,8 +102,8 @@ namespace GenericModConfigMenu
         {
             ui = new RootElement();
 
-            Vector2 newSize = new Vector2(800, Game1.viewport.Height - 128);
-            table.LocalPosition = new Vector2((Game1.viewport.Width - 800) / 2, 64);
+            Vector2 newSize = new Vector2(800, Game1.uiViewport.Height - 128);
+            table.LocalPosition = new Vector2((Game1.uiViewport.Width - 800) / 2, 64);
             foreach (Element opt in table.Children)
                 opt.LocalPosition = new Vector2(newSize.X / (table.Size.X / opt.LocalPosition.X), opt.LocalPosition.Y);
 

--- a/SpecificModConfigMenu.cs
+++ b/SpecificModConfigMenu.cs
@@ -63,8 +63,8 @@ namespace GenericModConfigMenu
 
             table = new Table();
             table.RowHeight = 50;
-            table.Size = new Vector2(Math.Min(1200, Game1.viewport.Width - 200), Game1.viewport.Height - 128 - 116);
-            table.LocalPosition = new Vector2((Game1.viewport.Width - table.Size.X) / 2, (Game1.viewport.Height - table.Size.Y) / 2);
+            table.Size = new Vector2(Math.Min(1200, Game1.uiViewport.Width - 200), Game1.uiViewport.Height - 128 - 116);
+            table.LocalPosition = new Vector2((Game1.uiViewport.Width - table.Size.X) / 2, (Game1.uiViewport.Height - table.Size.Y) / 2);
             foreach (var opt in modConfig.Options[ page ].Options)
             {
                 opt.SyncToMod();
@@ -309,27 +309,27 @@ namespace GenericModConfigMenu
         {
             string page = modConfig.Options[ currPage ].DisplayName;
             var titleLabel = new Label() { String = modManifest.Name + ( page == "" ? "" : " > " + page ), Bold = true };
-            titleLabel.LocalPosition = new Vector2((Game1.viewport.Width - titleLabel.Measure().X) / 2, 12 + 32);
+            titleLabel.LocalPosition = new Vector2((Game1.uiViewport.Width - titleLabel.Measure().X) / 2, 12 + 32);
             titleLabel.HoverTextColor = titleLabel.IdleTextColor;
             ui.AddChild(titleLabel);
 
             var cancelLabel = new Label() { String = "Cancel", Bold = true };
-            cancelLabel.LocalPosition = new Vector2(Game1.viewport.Width / 2 - 400, Game1.viewport.Height - 50 - 36);
+            cancelLabel.LocalPosition = new Vector2(Game1.uiViewport.Width / 2 - 400, Game1.uiViewport.Height - 50 - 36);
             cancelLabel.Callback = (Element e) => cancel();
             ui.AddChild(cancelLabel);
 
             var defaultLabel = new Label() { String = "Default", Bold = true };
-            defaultLabel.LocalPosition = new Vector2(Game1.viewport.Width / 2 - 200, Game1.viewport.Height - 50 - 36);
+            defaultLabel.LocalPosition = new Vector2(Game1.uiViewport.Width / 2 - 200, Game1.uiViewport.Height - 50 - 36);
             defaultLabel.Callback = (Element e) => revertToDefault();
             ui.AddChild(defaultLabel);
 
             var saveLabel = new Label() { String = "Save", Bold = true };
-            saveLabel.LocalPosition = new Vector2(Game1.viewport.Width / 2 + 50, Game1.viewport.Height - 50 - 36);
+            saveLabel.LocalPosition = new Vector2(Game1.uiViewport.Width / 2 + 50, Game1.uiViewport.Height - 50 - 36);
             saveLabel.Callback = (Element e) => save();
             ui.AddChild(saveLabel);
 
             var saveCloseLabel = new Label() { String = "Save&Close", Bold = true };
-            saveCloseLabel.LocalPosition = new Vector2( Game1.viewport.Width / 2 + 200, Game1.viewport.Height - 50 - 36 );
+            saveCloseLabel.LocalPosition = new Vector2( Game1.uiViewport.Width / 2 + 200, Game1.uiViewport.Height - 50 - 36 );
             saveCloseLabel.Callback = ( Element e ) => { save(); close(); };
             ui.AddChild( saveCloseLabel );
         }
@@ -370,42 +370,42 @@ namespace GenericModConfigMenu
         public override void draw(SpriteBatch b)
         {
             base.draw(b);
-            b.Draw(Game1.staminaRect, new Rectangle(0, 0, Game1.viewport.Width, Game1.viewport.Height), new Color(0, 0, 0, 192));
-            IClickableMenu.drawTextureBox(b, (Game1.viewport.Width - 800) / 2 - 32, 32, 800 + 64, 50 + 20, Color.White);
-            IClickableMenu.drawTextureBox(b, (Game1.viewport.Width - 800) / 2 - 32, Game1.viewport.Height - 50 - 20 - 32, 800 + 64, 50 + 20, Color.White);
+            b.Draw(Game1.staminaRect, new Rectangle(0, 0, Game1.uiViewport.Width, Game1.uiViewport.Height), new Color(0, 0, 0, 192));
+            IClickableMenu.drawTextureBox(b, (Game1.uiViewport.Width - 800) / 2 - 32, 32, 800 + 64, 50 + 20, Color.White);
+            IClickableMenu.drawTextureBox(b, (Game1.uiViewport.Width - 800) / 2 - 32, Game1.uiViewport.Height - 50 - 20 - 32, 800 + 64, 50 + 20, Color.White);
 
             ui.Draw(b);
 
             if ( keybindingOpt != null )
             {
-                b.Draw(Game1.staminaRect, new Rectangle(0, 0, Game1.viewport.Width, Game1.viewport.Height), new Color(0, 0, 0, 192));
+                b.Draw(Game1.staminaRect, new Rectangle(0, 0, Game1.uiViewport.Width, Game1.uiViewport.Height), new Color(0, 0, 0, 192));
 
-                int boxX = (Game1.viewport.Width - 650) / 2, boxY = (Game1.viewport.Height - 200) / 2;
+                int boxX = (Game1.uiViewport.Width - 650) / 2, boxY = (Game1.uiViewport.Height - 200) / 2;
                 IClickableMenu.drawTextureBox(b, boxX, boxY, 650, 200, Color.White);
 
                 string s = "Rebinding key: " + keybindingOpt.Name;
                 int sw = (int)Game1.dialogueFont.MeasureString(s).X;
-                b.DrawString(Game1.dialogueFont, s, new Vector2((Game1.viewport.Width - sw) / 2, boxY + 20), Game1.textColor);
+                b.DrawString(Game1.dialogueFont, s, new Vector2((Game1.uiViewport.Width - sw) / 2, boxY + 20), Game1.textColor);
 
                 s = "Press a key to rebind";
                 sw = (int)Game1.dialogueFont.MeasureString(s).X;
-                b.DrawString(Game1.dialogueFont, s, new Vector2((Game1.viewport.Width - sw) / 2, boxY + 100), Game1.textColor);
+                b.DrawString(Game1.dialogueFont, s, new Vector2((Game1.uiViewport.Width - sw) / 2, boxY + 100), Game1.textColor);
             }
 
             if ( keybinding2Opt != null )
             {
-                b.Draw( Game1.staminaRect, new Rectangle( 0, 0, Game1.viewport.Width, Game1.viewport.Height ), new Color( 0, 0, 0, 192 ) );
+                b.Draw( Game1.staminaRect, new Rectangle( 0, 0, Game1.uiViewport.Width, Game1.uiViewport.Height ), new Color( 0, 0, 0, 192 ) );
 
-                int boxX = (Game1.viewport.Width - 650) / 2, boxY = (Game1.viewport.Height - 200) / 2;
+                int boxX = (Game1.uiViewport.Width - 650) / 2, boxY = (Game1.uiViewport.Height - 200) / 2;
                 IClickableMenu.drawTextureBox( b, boxX, boxY, 650, 200, Color.White );
 
                 string s = "Rebinding key: " + keybinding2Opt.Name;
                 int sw = (int)Game1.dialogueFont.MeasureString(s).X;
-                b.DrawString( Game1.dialogueFont, s, new Vector2( ( Game1.viewport.Width - sw ) / 2, boxY + 20 ), Game1.textColor );
+                b.DrawString( Game1.dialogueFont, s, new Vector2( ( Game1.uiViewport.Width - sw ) / 2, boxY + 20 ), Game1.textColor );
 
                 s = "Press a key combination to rebind";
                 sw = ( int ) Game1.dialogueFont.MeasureString( s ).X;
-                b.DrawString( Game1.dialogueFont, s, new Vector2( ( Game1.viewport.Width - sw ) / 2, boxY + 100 ), Game1.textColor );
+                b.DrawString( Game1.dialogueFont, s, new Vector2( ( Game1.uiViewport.Width - sw ) / 2, boxY + 100 ), Game1.textColor );
             }
 
             drawMouse(b);
@@ -559,7 +559,7 @@ namespace GenericModConfigMenu
         {
             ui = new RootElement();
 
-            Vector2 newSize = new Vector2(Math.Min(1200, Game1.viewport.Width - 200), Game1.viewport.Height - 128 - 116);
+            Vector2 newSize = new Vector2(Math.Min(1200, Game1.uiViewport.Width - 200), Game1.uiViewport.Height - 128 - 116);
 
             foreach (Element opt in table.Children)
             {
@@ -569,7 +569,7 @@ namespace GenericModConfigMenu
             }
 
             table.Size = newSize;
-            table.LocalPosition = new Vector2((Game1.viewport.Width - table.Size.X) / 2, (Game1.viewport.Height - table.Size.Y) / 2);
+            table.LocalPosition = new Vector2((Game1.uiViewport.Width - table.Size.X) / 2, (Game1.uiViewport.Height - table.Size.Y) / 2);
             table.Scrollbar.Update();
             ui.AddChild(table);
             addDefaultLabels(mod);

--- a/SpecificModConfigMenu.cs
+++ b/SpecificModConfigMenu.cs
@@ -30,6 +30,8 @@ namespace GenericModConfigMenu
         private Dictionary<string, List<Image>> textures = new Dictionary<string, List<Image>>();
         private Queue<string> pendingTexChanges = new Queue<string>();
 
+        private bool DoingKeyBinding = false;
+
         public bool CanEdit<T>( IAssetInfo asset )
         {
             foreach ( var key in textures.Keys )
@@ -253,8 +255,7 @@ namespace GenericModConfigMenu
                     
                     
                     var localPos = new Vector2( table.Size.X / 2 - imgSize.X / 2, 0 );
-                    var baseRectPos = new Vector2( t.TextureRect.HasValue ? t.TextureRect.Value.X : 0,
-                                                   t.TextureRect.HasValue ? t.TextureRect.Value.Y : 0 );
+                    var baseRectPos = new Vector2( t.TextureRect?.X ?? 0, t.TextureRect?.Y ?? 0 );
 
                     var texs = new List<Image>();
                     if ( textures.ContainsKey( t.TexturePath ) )
@@ -412,6 +413,7 @@ namespace GenericModConfigMenu
 
             if (Constants.TargetPlatform != GamePlatform.Android)
             {
+                Mod.instance.Helper.Events.Input.ButtonReleased += CheckEscape;
                 foreach ( var label in optHovers )
                 {
                     if (!label.Hover)
@@ -469,11 +471,20 @@ namespace GenericModConfigMenu
             close();
         }
 
+        private void CheckEscape(object sender, ButtonReleasedEventArgs args) {
+            if (DoingKeyBinding) return;
+            if (args.Button.ToString() == "Escape") {
+                Mod.instance.Helper.Events.Input.ButtonReleased -= CheckEscape;
+                cancel();
+                }
+            }
+
         private SimpleModOption<SButton> keybindingOpt;
         private SimpleModOption<KeybindList> keybinding2Opt;
         private Label keybindingLabel;
         private void doKeybindingFor( SimpleModOption<SButton> opt, Label label )
         {
+            DoingKeyBinding = true;
             Game1.playSound("breathin");
             keybindingOpt = opt;
             keybindingLabel = label;
@@ -482,6 +493,7 @@ namespace GenericModConfigMenu
         }
         private void doKeybinding2For( SimpleModOption<KeybindList> opt, Label label )
         {
+            DoingKeyBinding = true;
             Game1.playSound( "breathin" );
             keybinding2Opt = opt;
             keybindingLabel = label;
@@ -491,6 +503,7 @@ namespace GenericModConfigMenu
 
         private void assignKeybinding(object sender, ButtonPressedEventArgs e)
         {
+            DoingKeyBinding = false;
             if ( keybindingOpt == null )
                 return;
             if ( !e.Button.TryGetKeyboard(out Keys keys) && !e.Button.TryGetController(out _) )
@@ -512,6 +525,7 @@ namespace GenericModConfigMenu
         }
         private void assignKeybinding2( object sender, ButtonsChangedEventArgs e )
         {
+            DoingKeyBinding = false;
             if ( keybinding2Opt == null )
                 return;
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Generic Mod Config Menu",
   "Author": "spacechase0",
-  "Version": "1.3.3",
+  "Version": "1.3.4-unofficial.2-pepoluan",
   "Description": "...",
   "UniqueID": "spacechase0.GenericModConfigMenu",
   "EntryDll": "GenericModConfigMenu.dll",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Generic Mod Config Menu",
   "Author": "spacechase0",
-  "Version": "1.3.4-unofficial.2-pepoluan",
+  "Version": "1.3.4-unofficial.4-pepoluan",
   "Description": "...",
   "UniqueID": "spacechase0.GenericModConfigMenu",
   "EntryDll": "GenericModConfigMenu.dll",


### PR DESCRIPTION
Players have complained that sometimes the buttons to close a mod's
config (i.e., Cancel or "Save & Close") are outside the screen so they
can't click it. Pressing "Esc" or "E" also doesn't close the dialog.

It is because GMCM is still using Game1.viewport which has the gameworld
coordinates, which on players using gameworld zoom < UI zoom will cause
the coordinates of the menu elements to be outside the UI viewport,
hence not seen.

I brute-fixed this by replacing all instances of Game1.viewport with
Game1.uiViewport, and at the very least this bug is no fixed.

Also, I added some "null catching" code in RegisterModMenu() because
there had been spurious reports of GMCM not working well with
CustomMusic (something I cannot replicate on my machine)

Binaries built after this fix (i.e., version 1.3.4-unofficial.2-pepoluan) is available on SourceForge: https://sourceforge.net/projects/sdvmod-generic-mod-config-menu/files/
